### PR TITLE
[04] reusing same port, seems more stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
+* [Issue 04](https://github.com/philosowaffle/vs-openapi-designer/issues/4) - Instability when launching/closing/updating the previewer
+
 ### Changed
 
 ## [0.0.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
+* Default Port from 9000 to 9005
+
 ## [0.0.5]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
                 "properties": {
                     "openApiDesigner.defaultPort": {
                         "type": "integer",
-                        "default": 9000,
+                        "default": 9005,
                         "description": "Default port in which the preview should be opened."
                     },
                     "openApiDesigner.previewInBrowser": {

--- a/src/oadServer.js
+++ b/src/oadServer.js
@@ -32,11 +32,11 @@ class Server {
 
     close() {
         /* loop through all sockets and destroy them */
-        Object.keys(this.connections).forEach(socketKey =>function(socketKey){
-            this.connections[socketKey].disconnect();
-            this.connections[socketKey].destroy();
-            logger.log("Closing socket " + socketKey + " for: " + this.fileName);
-        });
+        for(var key in this.connections){
+            this.connections[key].disconnect();
+            this.connections[key].destroy();
+            logger.log("Closing socket " + key + " for: " + this.fileName);
+        }
 
         /* after all the sockets are destroyed, we may close the server! */
         this.server.close(function(err){

--- a/src/oadViewer.js
+++ b/src/oadViewer.js
@@ -57,7 +57,7 @@ class Viewer {
 }
 
 /**
- * Get's a server for the given port and swaggerFile.
+ * Creates a viewer for the given port.
  *
  * @param {object} context
  * @param {string} port


### PR DESCRIPTION
[Issue](https://github.com/philosowaffle/vs-openapi-designer/issues/4)

- Switched to using single server, port, and viewer
- Viewer is now simply updated whenever a new file is selected as the target spec
- Watcher is also being cleaned up and re-created when the target watch dir changes
- Default port changed from 9000 to 9005