### PR TITLE
[19] fixing possible casing issue on linux OS's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "openapi-designer" extension will be documented in this file.
 
+## [0.2.1]
+
+### Fixed
+
+* [Issue 19](https://github.com/philosowaffle/vs-openapi-designer/issues/19) - Plugin not working on Linux due to case sensitivity in paths
+
 ## [0.2.0]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "openapi-designer",
     "displayName": "openapi-designer",
     "description": "Live Preview of OpenApi Schema in VS Code.",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "philosowaffle",
     "license": "SEE LICENSE IN LICENSE",
     "preview": true,

--- a/src/extension.js
+++ b/src/extension.js
@@ -132,7 +132,7 @@ function getActiveFile() {
     }
 
     var doc = editor.document;
-    return doc.fileName.toLowerCase();
+    return doc.fileName;
 }
 
 function getActivePath() {


### PR DESCRIPTION
[Issue 19](https://github.com/philosowaffle/vs-openapi-designer/issues/19)

Linux filepaths are case sensitive while Window's are not.  This is likely the cause of a bug where the extension would not work on linux machines.  Removed `.toLowerCase()` when fetching the file path.